### PR TITLE
Disable 'highmem' on QEMU device

### DIFF
--- a/server-overlay/etc/lava-server/dispatcher-config/devices/qemu-01.jinja2
+++ b/server-overlay/etc/lava-server/dispatcher-config/devices/qemu-01.jinja2
@@ -1,4 +1,5 @@
 {% extends 'qemu.jinja2' %}
+{% set machine = 'virt,highmem=off' %}
 {% set mac_addr = 'DE:AD:BE:EF:66:01' %}
 {% set memory = 1024 %}
 {% set netdevice = 'tap' %}


### PR DESCRIPTION
Release 2019.11 of LAVA Docker container images switched to Debian 10
(Buster). Dispatcher has been shipped with QEMU 3.x since then. QEMU 3.x
changed use of "highmem" property - it is now "on" by default [1].

Using kernel without LPAE support requires switching it off [2].

[1] https://bugzilla.redhat.com/show_bug.cgi?id=1633328#c6
[2] https://wiki.qemu.org/ChangeLog/3.0#Incompatible_changes

Resolves: #3